### PR TITLE
Updates base paths to reflect renamed project

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -89,7 +89,7 @@ export const Card: React.FC<CardProps> = ({
                 <div className="absolute inset-0 w-full h-full rounded" style={{ backfaceVisibility: "hidden" }}>
                     {card.card.image ? (
                         <img
-                            src={`/yu-gi-oh-1-kill-exodia/card_image/${card.card.image}`}
+                            src={`/yu-gi-oh-1-kill-simulator/card_image/${card.card.image}`}
                             alt={card.card.card_name}
                             className="w-full h-full object-contain"
                             style={{
@@ -128,7 +128,7 @@ export const Card: React.FC<CardProps> = ({
                     }}
                 >
                     <img
-                        src="/yu-gi-oh-1-kill-exodia/card_image/reverse.jpg"
+                        src="/yu-gi-oh-1-kill-simulator/card_image/reverse.jpg"
                         alt="Card Back"
                         className="w-full h-full object-contain"
                         style={{

--- a/src/components/FieldZone.tsx
+++ b/src/components/FieldZone.tsx
@@ -88,7 +88,7 @@ export const FieldZone: React.FC<FieldZoneProps> = ({
       `}
                 >
                     <img
-                        src={`/yu-gi-oh-1-kill-exodia/card_image/reverse.jpg`}
+                        src={`/yu-gi-oh-1-kill-simulator/card_image/reverse.jpg`}
                         alt={"dummy"}
                         className={`w-full h-full object-contain opacity-40`}
                         style={{

--- a/src/components/HoveredCardDisplay.tsx
+++ b/src/components/HoveredCardDisplay.tsx
@@ -16,7 +16,7 @@ export const HoveredCardDisplay = () => {
                             <img
                                 src={
                                     hoveredCard.card.image
-                                        ? `/yu-gi-oh-1-kill-exodia/card_image/${hoveredCard.card.image}`
+                                        ? `/yu-gi-oh-1-kill-simulator/card_image/${hoveredCard.card.image}`
                                         : ""
                                 }
                                 alt={hoveredCard.card.card_name}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
-    base: "/yu-gi-oh-1-kill-exodia/",
+    base: "/yu-gi-oh-1-kill-simulator/",
     plugins: [react()],
     resolve: {
         alias: {


### PR DESCRIPTION
Renames references from "yu-gi-oh-1-kill-exodia" to "yu-gi-oh-1-kill-simulator" across multiple files, including image paths and the Vite configuration base URL.

Ensures consistency with the updated project name and avoids confusion in resource handling.